### PR TITLE
Fix issue with 8.1 and upper versions

### DIFF
--- a/phpdocker/php-fpm-ix/Dockerfile
+++ b/phpdocker/php-fpm-ix/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8-fpm-alpine
+FROM php:8.0-fpm-alpine
 WORKDIR "/application"
 
 


### PR DESCRIPTION
Right now image cannot be built with existing php:8-fpm-alpine, because it tried to download latest image with this tag and under the hood, there are php:8.4-fpm-alpine. There are no packages such as php8-pecl-imagick, there are php83-pecl-imagick packages, so build process failed

pinned tag to appropriate version - php:8.0-fpm-alpine. So now, image can be built successfully